### PR TITLE
CSCETSIN-60: Refactor DataCite harvester

### DIFF
--- a/ckanext/oaipmh/datacite.py
+++ b/ckanext/oaipmh/datacite.py
@@ -8,7 +8,7 @@ from ckanext.oaipmh.harvester import OAIPMHHarvester
 log = logging.getLogger(__name__)
 
 class DataCiteHarvester(OAIPMHHarvester):
-    md_format = 'oai_datacite3' # 'cmdi0571'
+    md_format = 'oai_datacite' # 'cmdi0571'
     client = None  # used for testing
 
     def info(self):
@@ -24,60 +24,3 @@ class DataCiteHarvester(OAIPMHHarvester):
     def get_schema(self):
         from ckanext.kata.plugin import KataPlugin
         return KataPlugin.create_package_schema_oai_datacite()
-
-
-    def import_stage(self, harvest_object):
-        '''
-        The import stage will receive a HarvestObject object and will be
-        responsible for:
-        - performing any necessary action with the fetched object (e.g create a CKAN package).
-        Note: if this stage creates or updates a package, a reference
-        to the package should be added to the HarvestObject.
-        - creating the HarvestObject
-        - Package relation (if necessary)
-        - creating and storing any suitable HarvestObjectErrors that may occur.
-        - returning True if everything went as expected, False otherwise.
-
-        :param harvest_object: HarvestObject object
-        :returns: True if everything went right, False if errors were found
-        '''
-        if not harvest_object:
-            log.error('No harvest object received')
-            return False
-
-        if harvest_object.report_status == "deleted":
-            if harvest_object.package_id:
-                get_action('package_delete')({'model': model, 'session': model.Session, 'user': 'harvest'}, {'id': harvest_object.package_id})
-                return True
-            return True
-
-        if not harvest_object.content:
-            self._save_object_error('Import: Empty content for object {id}'.format(
-                id=harvest_object.id), harvest_object)
-
-            return False
-
-        content = json.loads(harvest_object.content)
-
-
-        package_dict = content.pop('unified')
-
-        try:
-            package = model.Package.get(harvest_object.harvest_source_id)
-            if package and package.owner_org:
-                package_dict['owner_org'] = package.owner_org
-
-            schema = self.get_schema()
-            result = self._create_or_update_package(package_dict,
-                                                    harvest_object,
-                                                    schema=schema,
-                                                    )
-
-        except Exception as e:
-            import traceback
-            traceback.print_exc()
-            self._save_object_error('Import: Could not create {id}. {e}'.format(
-                id=harvest_object.id, e=e), harvest_object)
-            return False
-
-        return result

--- a/ckanext/oaipmh/datacite.py
+++ b/ckanext/oaipmh/datacite.py
@@ -19,8 +19,3 @@ class DataCiteHarvester(OAIPMHHarvester):
             'title': 'OAI-PMH DataCite',
             'description': 'Harvests DataCite v.3.1 datasets'
         }
-
-
-    def get_schema(self):
-        from ckanext.kata.plugin import KataPlugin
-        return KataPlugin.create_package_schema_oai_datacite()

--- a/ckanext/oaipmh/datacite_reader.py
+++ b/ckanext/oaipmh/datacite_reader.py
@@ -1,12 +1,12 @@
 # coding: utf-8
 
-import datetime
-import oaipmh.common
-
-from ckanext.kata.utils import get_package_id_by_pid, get_unique_package_id
-from ckanext.oaipmh.importcore import generic_xml_metadata_reader
-from lxml import etree
 from pylons import config
+
+from ckan import plugins as p
+
+import oaipmh.common
+from ckanext.oaipmh.importcore import generic_xml_metadata_reader
+from ckanext.oaipmh.interfaces import IOAIPMHHarvester
 
 # for debug
 import logging
@@ -34,144 +34,12 @@ class DataCiteReader(object):
         :param xml: xml element (lxml)
         :return: oaipmh.common.Metadata object generated from xml
         """
+        from ckanext.oaipmh.datacite import DataCiteHarvester
+
+        for harvester in p.PluginImplementations(IOAIPMHHarvester):
+            package_dict = harvester.get_oaipmh_package_dict(DataCiteHarvester.md_format, xml)
+
         result = generic_xml_metadata_reader(xml).getMap()
-        result['unified'] = self.read_data(xml)
+        result['package_dict'] = package_dict
         return oaipmh.common.Metadata(xml, result)
 
-
-    def read_data(self, xml):
-        """ Extract package data from given XML.
-        :param xml: xml element (lxml)
-        :return: dictionary
-        """
-
-        # MAP DATACITE MANDATORY FIELD
-
-        # Identifier to primary pid
-        identifier = xml.find('.//{http://datacite.org/schema/kernel-3}identifier')
-        pids = [{
-            'id': identifier.text, 
-            'type': 'primary', 
-            'provider': identifier.get('identifierType')}]
-
-        # Creator name to agent
-        # TODO: map nameIdentifier to agent.id and nameIdentifierScheme and schemeURI 
-        # to extras
-        agents = []
-        for creator in xml.findall('.//{http://datacite.org/schema/kernel-3}creator'):
-            creatorName = creator.find('.//{http://datacite.org/schema/kernel-3}creatorName').text
-            creatorAffiliation = creator.find('.//{http://datacite.org/schema/kernel-3}affiliation').text
-            agents.append({
-                'role': u'author', 
-                'name': creatorName, 
-                'organisation': creatorAffiliation
-                })
-
-        # Primary title to title
-        # TODO: if titleType is present, check to find out if title is actually primary
-        # TODO: map non-primary titles to extras
-        title = xml.find('.//{http://datacite.org/schema/kernel-3}title').text
-        langtitle = [{'lang': 'en', 'value': title}] # Assuming we always harvest English
-
-        # Publisher to contact
-        publisher = xml.find('.//{http://datacite.org/schema/kernel-3}publisher').text
-        contacts = [{'name': publisher}]
-
-        # Publication year to event
-        publication_year = xml.find('.//{http://datacite.org/schema/kernel-3}publicationYear').text
-        events = [{'type': u'published', 'when': publication_year, 'who': publisher, 'descr': u'Dataset was published'}]
-
-
-        # MAP DATACITE RECOMMENDED FIELDS
-
-        # Subject to tags
-        # TODO: map subjectsScheme and schemeURI to extras
-
-        # Contributor to agent
-        # TODO: map nameIdentifier to agent.id, nameIdentifierScheme, schemeURI and 
-        # contributorType to extras
-        for contributor in xml.findall('.//{http://datacite.org/schema/kernel-3}contributor'):
-            contributorName = contributor.find('.//{http://datacite.org/schema/kernel-3}contributorName').text
-            contributorAffiliation = contributor.find('.//{http://datacite.org/schema/kernel-3}affiliation').text
-            agents.append({
-                'role': u'contributor', 
-                'name': contributorName, 
-                'organisation': contributorAffiliation
-                })
-
-        # Date to event
-        for date in xml.findall('.//{http://datacite.org/schema/kernel-3}date'):
-            events.append({
-              'type': date.get('dateType'),
-              'when': date.text,
-              'who': u'unknown',
-              'descr': date.get('dateType'),
-              })
-
-        # ResourceType to extra
-        # TODO: map resourceType and resourceTypeGeneral to extras
-
-        # RelatedIdentifier to showcase
-        # TODO: map RelatedIdentifier to showcase title, relatedIdentifierType, relationType, 
-        # relatedMetadataScheme, schemeURI and schemeType to showcase description
-
-        # Description to langnotes
-        description = ''
-        for element in xml.findall('.//{http://datacite.org/schema/kernel-3}description'):
-            description += element.get('descriptionType') + ': ' + element.text + ' '
-        langnotes = [{
-          'lang': 'en', # Assuming we always harvest English
-          'value': description,
-          }]
-
-        # GeoLocation to geograhic_coverage
-        # TODO: map geoLocationPoint and geoLocationBox to extras, geoLocationPlace to 
-        # geographic_coverage
-
-
-        # MAP DATACITE OPTIONAL FIELDS
-
-        # Language to language
-        # TODO: map language to language
-
-        # AlternateIdentifier to pids
-        # TODO: map AlternateIdentifier to pids.id, alternateIdentifierType to pids.provider
-
-        # Size to extra
-        # TODO: map size to extra
-
-        # Format to resources
-        # TODO: map format to resources.format
-
-        # Version to extra
-        # DataCite version is a string such as 'v3.2.1' and can't be used as Etsin version
-        # TODO: map version to extra
-
-        # Rights to license
-        license_URL = ''
-        for right in xml.findall('.//{http://datacite.org/schema/kernel-3}rights'):
-            license_URL += right.text + ' ' + right.get('rightsURI') + ' '
-
-
-        # OTHER - REQUIRED BY CKANEXT-HARVEST
-
-        # Get or create package id
-        existing_package_id = get_package_id_by_pid(identifier.text, u'primary')
-        package_id = existing_package_id if existing_package_id else get_unique_package_id()
-
-        result = {
-                  'agent': agents,
-                  'contact': contacts,
-                  'event': events,
-                  'id': package_id,
-                  'langnotes': langnotes,
-                  'langtitle': langtitle,
-                  'license_URL': license_URL,
-                  'pids': pids,
-                  'title': title,
-                  'type': 'dataset',
-                  'version': datetime.datetime.now().strftime("%Y-%m-%d")
-                  }
-
-
-        return result

--- a/ckanext/oaipmh/importformats.py
+++ b/ckanext/oaipmh/importformats.py
@@ -8,6 +8,7 @@ import oaipmh.metadata as om
 import lxml.etree
 from fn.uniform import range
 from ckanext.oaipmh.cmdi_reader import CmdiReader
+from ckanext.oaipmh.datacite_reader import DataCiteReader
 
 import importcore
 
@@ -170,7 +171,7 @@ def create_metadata_registry(harvest_type=None, service_url=None):
     registry = om.MetadataRegistry()
     # registry.registerReader('oai_dc', dc_metadata_reader(harvest_type or 'default'))
     registry.registerReader('cmdi0571', CmdiReader(service_url))
-    # registry.registerReader('oai_datacite3', DataCiteReader())
+    registry.registerReader('oai_datacite', DataCiteReader())
     registry.registerReader('nrd', nrd_metadata_reader)
     registry.registerReader('rdf', rdf_reader)
     registry.registerReader('xml', xml_reader)


### PR DESCRIPTION
DataCite harvester should
- use format oai_datacite instead of oai_datacite3
- use common import stage with other OAI-PMH harvesters
- not contain any mapping code
- look for the correct mapper by querying plugins that implement a certain interface

When testing this PR, you should use the CSCETSIN-61 branch of ckanext-etsin.